### PR TITLE
Fix database name Windows incompatibility

### DIFF
--- a/update.py
+++ b/update.py
@@ -133,7 +133,7 @@ def update():
             dprint("Finished.")
             return
     
-    today = datetime.now().isoformat()
+    today = "_".join(datetime.now().isoformat().split(":"))
     if not os.path.exists(f'data/backups/{today}.html'):
         open(f'data/backups/{today}.html', 'x').close()
     open(f'data/backups/{today}.html', 'w').write(r.content.decode())


### PR DESCRIPTION
Replaces all colons in the backup name with underscores. Recommend changing previous backup names to reflect this change.